### PR TITLE
Having timeouts for http connections is a good idea.

### DIFF
--- a/cmd/bucky/common.go
+++ b/cmd/bucky/common.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 )
 
 import "github.com/golang/snappy"
@@ -39,10 +40,16 @@ func GetHTTP() *http.Client {
 		return httpClient
 	}
 
-	httpClient = new(http.Client)
-
-	// Set a 30 second timeout on all operations
-	//httpClient.Timeout = 30 * time.Second
+	httpClient := &http.Client{
+		Timeout: 600 * time.Second,
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout:   1 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).Dial,
+			ResponseHeaderTimeout: 1 * time.Second,
+		},
+	}
 
 	return httpClient
 }


### PR DESCRIPTION
In original implementation it will hang on connection forewer
if server side is accepting TCP, but does not reply back.

This change handles different http.Client timeouts:
- Dial timeout
- Response header timeout
- Keepalive timeout
- Client timeout