### PR TITLE
Add modify command

### DIFF
--- a/cmd/bucky/modify.go
+++ b/cmd/bucky/modify.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sort"
 	"syscall"
+	"time"
 
 	"github.com/go-graphite/buckytools/whisper"
 )
@@ -14,6 +15,7 @@ var (
 	resizeArchiveIndex int
 	resizeNewRetention string
 	resizeAgg          string
+	resizeUseNow       bool
 )
 
 func init() {
@@ -30,6 +32,7 @@ func init() {
 	c.Flag.IntVar(&resizeArchiveIndex, "index", -1, "archive index")
 	c.Flag.StringVar(&resizeNewRetention, "retention", "", "new retention")
 	c.Flag.StringVar(&resizeAgg, "agg", "", "new aggregation method")
+	c.Flag.BoolVar(&resizeUseNow, "now", false, "use now to find archive offset")
 }
 
 // modifyCommand runs this subcommand.
@@ -92,138 +95,150 @@ func modifyCommand(c Command) int {
 		panic(err)
 	}
 
-	newFile := result.File()
-	oldFile := target.File()
-
 	if resizeArchiveIndex != -1 {
-		newArchives := result.ArchiveInfos()
-		oldArchives := target.ArchiveInfos()
-		for i, oldArchive := range oldArchives {
-			if _, err := oldFile.Seek(oldArchive.Offset(), 0); err != nil {
-				panic(err)
-			}
-			body := make([]byte, oldArchive.Size())
-			if _, err := oldFile.Read(body); err != nil {
-				panic(err)
-			}
-			if _, err := newFile.WriteAt(body, newArchives[i].Offset()); err != nil {
-				panic(err)
-			}
-		}
-
-		oldArchive := oldArchives[resizeArchiveIndex]
-		dps := target.ReadSeries(oldArchive.Offset(), int64(oldArchive.End()), &oldArchive)
-
-		startPoint := dps[0]
-		for _, dp := range dps {
-			if dp.Interval() > 0 && dp.Interval() < startPoint.Interval() {
-				startPoint = dp
-			}
-		}
-
-		startInterval := 0
-		newArchive := newArchives[resizeArchiveIndex]
-
-		// best-effort backfilling of extended dps
-		{
-			lowerArchive := newArchive
-			for _, arc := range newArchives {
-				if arc.SecondsPerPoint() > newArchive.SecondsPerPoint() && (lowerArchive.SecondsPerPoint() == newArchive.SecondsPerPoint() || lowerArchive.SecondsPerPoint() > arc.SecondsPerPoint()) {
-					lowerArchive = arc
-				}
-			}
-			extendedStart := startPoint.Interval() - (newArchive.NumberOfPoints()-oldArchive.NumberOfPoints())*newArchive.SecondsPerPoint()
-			extendedEnd := startPoint.Interval()
-
-			// println("extendedStart", extendedStart)
-			// println("extendedEnd", extendedEnd)
-
-			fromInterval := lowerArchive.Interval(extendedStart)
-			untilInterval := lowerArchive.Interval(extendedEnd)
-			baseInterval := result.GetBaseInterval(&lowerArchive)
-			fromOffset := lowerArchive.PointOffset(baseInterval, fromInterval) - whisper.PointSize
-			untilOffset := lowerArchive.PointOffset(baseInterval, untilInterval) + whisper.PointSize
-
-			lowerDps := result.ReadSeries(fromOffset, untilOffset, &lowerArchive)
-			// pretty.Println(lowerDps)
-			lowerIntervalMap := map[int]float64{}
-			for _, dp := range lowerDps {
-				lowerIntervalMap[dp.Interval()] = dp.Value()
-			}
-			// startInterval = 0
-			for ts := extendedStart; ts < extendedEnd; ts += newArchive.SecondsPerPoint() {
-				val, ok := lowerIntervalMap[lowerArchive.Interval(ts)-lowerArchive.SecondsPerPoint()]
-				// println(ts, lowerArchive.Interval(ts))
-				if !ok {
-					continue
-				}
-
-				switch result.AggregationMethod() {
-				case whisper.Sum:
-					val /= float64(lowerArchive.SecondsPerPoint() / newArchive.SecondsPerPoint())
-				}
-
-				dp := whisper.NewDataPoint(ts, val)
-				// println(dp.Interval(), val)
-				if startInterval == 0 {
-					startInterval = ts
-					newFile.WriteAt(dp.Bytes(), newArchive.Offset())
-				} else {
-					newFile.WriteAt(dp.Bytes(), newArchive.PointOffset(startInterval, dp.Interval()))
-				}
-			}
-		}
-
-		if startInterval == 0 {
-			startInterval = startPoint.Interval()
-			newFile.WriteAt(startPoint.Bytes(), newArchive.Offset())
-		} else {
-			newFile.WriteAt(startPoint.Bytes(), newArchive.PointOffset(startInterval, startPoint.Interval()))
-		}
-
-		// pretty.Println(lowerArchive)
-
-		for _, dp := range dps {
-			if dp.Interval() == 0 || dp.Interval() == startInterval {
-				continue
-			}
-			// if _, err := newFile.WriteAt(dp.Bytes(), newArchive.Offset()+whisper.PointSize*int64(i)); err != nil {
-			// 	panic(err)
-			// }
-			// println(dp.Interval(), dp.Value())
-			if _, err := newFile.WriteAt(dp.Bytes(), newArchive.PointOffset(startInterval, dp.Interval())); err != nil {
-				panic(err)
-			}
-		}
+		resizeArchive(target, result)
 	} else {
-		oldArchives := target.ArchiveInfos()
-		sort.Slice(oldArchives, func(i, j int) bool {
-			return oldArchives[i].SecondsPerPoint() < oldArchives[j].SecondsPerPoint()
-		})
-		newArchives := result.ArchiveInfos()
-		sort.Slice(newArchives, func(i, j int) bool {
-			return newArchives[i].SecondsPerPoint() < newArchives[j].SecondsPerPoint()
-		})
-
-		for i, oldArchive := range oldArchives {
-			dps := target.ReadSeries(oldArchive.Offset(), int64(oldArchive.End()), &oldArchive)
-			for j, dp := range dps {
-				if i > 0 {
-					if target.AggregationMethod() == whisper.Average && aggMethod == whisper.Sum {
-						dp = whisper.NewDataPoint(dp.Interval(), dp.Value()*float64(oldArchives[i].SecondsPerPoint()/oldArchives[i-1].SecondsPerPoint()))
-					} else if target.AggregationMethod() == whisper.Sum && aggMethod == whisper.Average {
-						dp = whisper.NewDataPoint(dp.Interval(), dp.Value()/float64(oldArchives[i].SecondsPerPoint()/oldArchives[i-1].SecondsPerPoint()))
-					}
-				}
-
-				if _, err := newFile.WriteAt(dp.Bytes(), newArchives[i].Offset()+whisper.PointSize*int64(j)); err != nil {
-					panic(err)
-				}
-			}
-		}
+		modifyAgg(target, result, aggMethod)
 	}
 
 	result.Close()
 
 	return 0
+}
+
+func modifyAgg(target, result *whisper.Whisper, aggMethod whisper.AggregationMethod) {
+	oldArchives := target.ArchiveInfos()
+	sort.Slice(oldArchives, func(i, j int) bool {
+		return oldArchives[i].SecondsPerPoint() < oldArchives[j].SecondsPerPoint()
+	})
+	newArchives := result.ArchiveInfos()
+	sort.Slice(newArchives, func(i, j int) bool {
+		return newArchives[i].SecondsPerPoint() < newArchives[j].SecondsPerPoint()
+	})
+	newFile := result.File()
+	for i, oldArchive := range oldArchives {
+		dps := target.ReadSeries(oldArchive.Offset(), int64(oldArchive.End()), &oldArchive)
+		for j, dp := range dps {
+			if i > 0 {
+				if target.AggregationMethod() == whisper.Average && aggMethod == whisper.Sum {
+					dp = whisper.NewDataPoint(dp.Interval(), dp.Value()*float64(oldArchives[i].SecondsPerPoint()/oldArchives[i-1].SecondsPerPoint()))
+				} else if target.AggregationMethod() == whisper.Sum && aggMethod == whisper.Average {
+					dp = whisper.NewDataPoint(dp.Interval(), dp.Value()/float64(oldArchives[i].SecondsPerPoint()/oldArchives[i-1].SecondsPerPoint()))
+				}
+			}
+
+			if _, err := newFile.WriteAt(dp.Bytes(), newArchives[i].Offset()+whisper.PointSize*int64(j)); err != nil {
+				panic(err)
+			}
+		}
+	}
+}
+
+func resizeArchive(target, result *whisper.Whisper) {
+	newFile := result.File()
+	oldFile := target.File()
+	newArchives := result.ArchiveInfos()
+	oldArchives := target.ArchiveInfos()
+	for i, oldArchive := range oldArchives {
+		if _, err := oldFile.Seek(oldArchive.Offset(), 0); err != nil {
+			panic(err)
+		}
+		body := make([]byte, oldArchive.Size())
+		if _, err := oldFile.Read(body); err != nil {
+			panic(err)
+		}
+		if _, err := newFile.WriteAt(body, newArchives[i].Offset()); err != nil {
+			panic(err)
+		}
+	}
+
+	oldArchive := oldArchives[resizeArchiveIndex]
+	dps := target.ReadSeries(oldArchive.Offset(), int64(oldArchive.End()), &oldArchive)
+
+	oldStartPoint := dps[0]
+	for _, dp := range dps {
+		if dp.Interval() > 0 && dp.Interval() < oldStartPoint.Interval() {
+			oldStartPoint = dp
+		}
+	}
+
+	startInterval := 0
+	newArchive := newArchives[resizeArchiveIndex]
+
+	// best-effort backfilling of extended dps
+	{
+		lowerArchive := newArchive
+		for _, arc := range newArchives {
+			if arc.SecondsPerPoint() > newArchive.SecondsPerPoint() && (lowerArchive.SecondsPerPoint() == newArchive.SecondsPerPoint() || lowerArchive.SecondsPerPoint() > arc.SecondsPerPoint()) {
+				lowerArchive = arc
+			}
+		}
+		offsetInterval := oldStartPoint.Interval()
+		if resizeUseNow {
+			offsetInterval = int(time.Now().Add(time.Duration(-1 * int64(newArchive.MaxRetention()))).Unix())
+		}
+
+		extendedStart := offsetInterval - (newArchive.NumberOfPoints()-oldArchive.NumberOfPoints())*newArchive.SecondsPerPoint()
+		extendedEnd := offsetInterval
+
+		// println("extendedStart", extendedStart)
+		// println("extendedEnd", extendedEnd)
+
+		fromInterval := lowerArchive.Interval(extendedStart)
+		untilInterval := lowerArchive.Interval(extendedEnd)
+		baseInterval := result.GetBaseInterval(&lowerArchive)
+		fromOffset := lowerArchive.PointOffset(baseInterval, fromInterval) - whisper.PointSize
+		untilOffset := lowerArchive.PointOffset(baseInterval, untilInterval) + whisper.PointSize
+
+		lowerDps := result.ReadSeries(fromOffset, untilOffset, &lowerArchive)
+		// pretty.Println(lowerDps)
+		lowerIntervalMap := map[int]float64{}
+		for _, dp := range lowerDps {
+			lowerIntervalMap[dp.Interval()] = dp.Value()
+		}
+		// startInterval = 0
+		for ts := extendedStart; ts < extendedEnd; ts += newArchive.SecondsPerPoint() {
+			val, ok := lowerIntervalMap[lowerArchive.Interval(ts)-lowerArchive.SecondsPerPoint()]
+			// println(ts, lowerArchive.Interval(ts))
+			if !ok {
+				continue
+			}
+
+			switch result.AggregationMethod() {
+			case whisper.Sum:
+				val /= float64(lowerArchive.SecondsPerPoint() / newArchive.SecondsPerPoint())
+			}
+
+			dp := whisper.NewDataPoint(ts, val)
+			// println(dp.Interval(), val)
+			if startInterval == 0 {
+				startInterval = ts
+				newFile.WriteAt(dp.Bytes(), newArchive.Offset())
+			} else {
+				newFile.WriteAt(dp.Bytes(), newArchive.PointOffset(startInterval, dp.Interval()))
+			}
+		}
+	}
+
+	if startInterval == 0 {
+		startInterval = oldStartPoint.Interval()
+		newFile.WriteAt(oldStartPoint.Bytes(), newArchive.Offset())
+	} else {
+		newFile.WriteAt(oldStartPoint.Bytes(), newArchive.PointOffset(startInterval, oldStartPoint.Interval()))
+	}
+
+	// pretty.Println(lowerArchive)
+
+	for _, dp := range dps {
+		if dp.Interval() == 0 || dp.Interval() == startInterval {
+			continue
+		}
+		// if _, err := newFile.WriteAt(dp.Bytes(), newArchive.Offset()+whisper.PointSize*int64(i)); err != nil {
+		// 	panic(err)
+		// }
+		// println(dp.Interval(), dp.Value())
+		if _, err := newFile.WriteAt(dp.Bytes(), newArchive.PointOffset(startInterval, dp.Interval())); err != nil {
+			panic(err)
+		}
+	}
 }

--- a/cmd/bucky/modify.go
+++ b/cmd/bucky/modify.go
@@ -21,7 +21,7 @@ func init() {
 	short := ""
 	long := ``
 
-	c := NewCommand(resizeCommand, "resize", usage, short, long)
+	c := NewCommand(modifyCommand, "modify", usage, short, long)
 	SetupCommon(c)
 	SetupHostname(c)
 	SetupSingle(c)
@@ -32,8 +32,8 @@ func init() {
 	c.Flag.StringVar(&resizeAgg, "agg", "", "new aggregation method")
 }
 
-// resizeCommand runs this subcommand.
-func resizeCommand(c Command) int {
+// modifyCommand runs this subcommand.
+func modifyCommand(c Command) int {
 	resizeFile, err := os.Open(resizeFilename)
 	if err != nil {
 		panic(err)

--- a/cmd/bucky/resize.go
+++ b/cmd/bucky/resize.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"sort"
+
+	"github.com/go-graphite/buckytools/whisper"
+)
+
+var (
+	resizeFilename     string
+	resizeArchiveIndex int
+	resizeNewRetention string
+	resizeAgg          string
+)
+
+func init() {
+	usage := ""
+	short := ""
+	long := ``
+
+	c := NewCommand(resizeCommand, "resize", usage, short, long)
+	SetupCommon(c)
+	SetupHostname(c)
+	SetupSingle(c)
+
+	c.Flag.StringVar(&resizeFilename, "f", "", "whisper file to resize")
+	c.Flag.IntVar(&resizeArchiveIndex, "index", -1, "archive index")
+	c.Flag.StringVar(&resizeNewRetention, "retention", "", "new retention")
+	c.Flag.StringVar(&resizeAgg, "agg", "", "new aggregation method")
+}
+
+// resizeCommand runs this subcommand.
+func resizeCommand(c Command) int {
+	target, err := whisper.Open(resizeFilename)
+	if err != nil {
+		panic(err)
+	}
+
+	newRetentions := target.Retentions()
+	if resizeArchiveIndex != -1 {
+		retention, err := whisper.ParseRetentionDef(resizeNewRetention)
+		if err != nil {
+			panic(err)
+		}
+		newRetentions[resizeArchiveIndex] = retention
+	}
+
+	aggMethod := target.AggregationMethod()
+	if resizeAgg != "" {
+		switch resizeAgg {
+		case "average":
+			aggMethod = whisper.Average
+		case "sum":
+			aggMethod = whisper.Sum
+		default:
+			panic("unsupported aggregation method")
+		}
+	}
+
+	result, err := whisper.Create(resizeFilename+".new", newRetentions, aggMethod, target.XFF())
+	if err != nil {
+		panic(err)
+	}
+
+	newFile := result.File()
+	oldFile := target.File()
+
+	if resizeArchiveIndex != -1 {
+		newArchives := result.ArchiveInfos()
+		for i, oldArchive := range target.ArchiveInfos() {
+			if _, err := oldFile.Seek(oldArchive.Offset(), 0); err != nil {
+				panic(err)
+			}
+			body := make([]byte, oldArchive.Size())
+			if _, err := oldFile.Read(body); err != nil {
+				panic(err)
+			}
+			if _, err := newFile.WriteAt(body, newArchives[i].Offset()); err != nil {
+				panic(err)
+			}
+		}
+
+		tarchive := newArchives[resizeArchiveIndex]
+		dps := result.ReadSeries(tarchive.Offset(), int64(tarchive.End()), &tarchive)
+		sort.Sort(whisper.DataPoints(dps))
+		for i, dp := range dps {
+			if _, err := newFile.WriteAt(dp.Bytes(), tarchive.Offset()+whisper.PointSize*int64(i)); err != nil {
+				panic(err)
+			}
+		}
+	} else {
+		oldArchives := target.ArchiveInfos()
+		sort.Slice(oldArchives, func(i, j int) bool {
+			return oldArchives[i].SecondsPerPoint() < oldArchives[j].SecondsPerPoint()
+		})
+		newArchives := result.ArchiveInfos()
+		sort.Slice(newArchives, func(i, j int) bool {
+			return newArchives[i].SecondsPerPoint() < newArchives[j].SecondsPerPoint()
+		})
+
+		for i, oldArchive := range oldArchives {
+			dps := target.ReadSeries(oldArchive.Offset(), int64(oldArchive.End()), &oldArchive)
+			for j, dp := range dps {
+				if i > 0 {
+					if target.AggregationMethod() == whisper.Average && aggMethod == whisper.Sum {
+						dp = whisper.NewDataPoint(dp.Interval(), dp.Value()*float64(oldArchives[i].SecondsPerPoint()/oldArchives[i-1].SecondsPerPoint()))
+					} else if target.AggregationMethod() == whisper.Sum && aggMethod == whisper.Average {
+						dp = whisper.NewDataPoint(dp.Interval(), dp.Value()/float64(oldArchives[i].SecondsPerPoint()/oldArchives[i-1].SecondsPerPoint()))
+					}
+				}
+
+				if _, err := newFile.WriteAt(dp.Bytes(), newArchives[i].Offset()+whisper.PointSize*int64(j)); err != nil {
+					panic(err)
+				}
+			}
+		}
+	}
+
+	result.Close()
+
+	return 0
+}

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -142,6 +142,7 @@ func Create(path string, retentions Retentions, aggregationMethod AggregationMet
 	if err = validateRetentions(retentions); err != nil {
 		return nil, err
 	}
+
 	_, err = os.Stat(path)
 	if err == nil {
 		return nil, os.ErrExist
@@ -154,6 +155,15 @@ func Create(path string, retentions Retentions, aggregationMethod AggregationMet
 	// Lock file as carbon-cache.py would
 	if err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
 		file.Close()
+		return nil, err
+	}
+
+	return Create2(file, retentions, aggregationMethod, xFilesFactor)
+}
+
+func Create2(file *os.File, retentions Retentions, aggregationMethod AggregationMethod, xFilesFactor float32) (whisper *Whisper, err error) {
+	sort.Sort(RetentionsByPrecision{retentions})
+	if err = validateRetentions(retentions); err != nil {
 		return nil, err
 	}
 	whisper = new(Whisper)

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -406,7 +406,7 @@ func (whisper *Whisper) archiveUpdateMany(archive *archiveInfo, points []*TimeSe
 	alignedPoints := alignPoints(archive, points)
 	intervals, packedBlocks := PackSequences(archive, alignedPoints)
 
-	baseInterval := whisper.getBaseInterval(archive)
+	baseInterval := whisper.GetBaseInterval(archive)
 	if baseInterval == 0 {
 		baseInterval = intervals[0]
 	}
@@ -495,14 +495,14 @@ func PackSequences(archive *archiveInfo, points []dataPoint) (intervals []int, p
 	This method retrieves the baseInterval and the
 */
 func (whisper *Whisper) getPointOffset(start int, archive *archiveInfo) int64 {
-	baseInterval := whisper.getBaseInterval(archive)
+	baseInterval := whisper.GetBaseInterval(archive)
 	if baseInterval == 0 {
 		return archive.Offset()
 	}
 	return archive.PointOffset(baseInterval, start)
 }
 
-func (whisper *Whisper) getBaseInterval(archive *archiveInfo) int {
+func (whisper *Whisper) GetBaseInterval(archive *archiveInfo) int {
 	baseInterval, err := whisper.readInt(archive.Offset())
 	if err != nil {
 		panic("Failed to read baseInterval")
@@ -618,7 +618,7 @@ func (whisper *Whisper) Fetch(fromTime, untilTime int) (timeSeries *TimeSeries, 
 
 	fromInterval := archive.Interval(fromTime)
 	untilInterval := archive.Interval(untilTime)
-	baseInterval := whisper.getBaseInterval(&archive)
+	baseInterval := whisper.GetBaseInterval(&archive)
 
 	if baseInterval == 0 {
 		step := archive.secondsPerPoint


### PR DESCRIPTION
Modify command supports two operations: resize, or update aggregation policy.

Resize mode allows user to resize one archive at a time. It only change the
targeting archive and does not affect other archives. Use -index to specify
resized archives.

Use -retention to specify new policy (with the same format in whisper
configuration). To resize to bigger time range, modify command upsample data
from lower-resolution archives.

Example:
	bucky modify -index 1 -retention 1m:30d -f 100_olddata.wsp

Change aggregation policy. Other than changing policy, this command would also
try to correct data if it's changing policy from average -> sum, or sum -> average.
For other types of changes, it would only do a simple data copy.

Example:
	bucky modify -f small.wsp.new -agg average

By default, both tool would copy the original whisper file as a new back in the
same location.

**Note**: the key difference between modify resize and [whisper-resize.py](https://github.com/graphite-project/whisper/blob/master/bin/whisper-resize.py) is that modify command would manipulate the archives directly instead of through the update_many/UpdateMany call in whipser library. So it doesn't propagate to lower archives.