### PR TITLE
Adopt github.com/go-graphite/go-whisper library

### DIFF
--- a/cmd/bucky-isempty/main.go
+++ b/cmd/bucky-isempty/main.go
@@ -8,12 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-)
 
-import (
 	"github.com/go-graphite/buckytools"
 	"github.com/go-graphite/buckytools/metrics"
-	"github.com/go-graphite/buckytools/whisper"
+	"github.com/go-graphite/go-whisper"
 )
 
 // Command Line Flags

--- a/cmd/bucky/backfill.go
+++ b/cmd/bucky/backfill.go
@@ -189,7 +189,7 @@ func backfillCommand(c Command) int {
 	if c.Flag.Arg(0) != "-" {
 		fd, err = os.Open(c.Flag.Arg(0))
 		if err != nil {
-			log.Fatal("Error opening json map: %s", err)
+			log.Fatalf("Error opening json map: %s", err)
 		}
 		defer fd.Close()
 	} else {

--- a/cmd/bucky/locate.go
+++ b/cmd/bucky/locate.go
@@ -63,7 +63,7 @@ func LocateJSONMetrics(fd io.Reader) map[string]string {
 
 	err = json.Unmarshal(blob, &metrics)
 	if err != nil {
-		log.Fatal("Error unmarshalling JSON data: %s", err)
+		log.Fatalf("Error unmarshalling JSON data: %s", err)
 	}
 
 	return LocateSliceMetrics(metrics)

--- a/cmd/bucky/modify.go
+++ b/cmd/bucky/modify.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 	"time"
 
+	// TODO: migrate to github.com/go-graphite/go-whisper
 	"github.com/go-graphite/buckytools/whisper"
 )
 

--- a/cmd/bucky/restore.go
+++ b/cmd/bucky/restore.go
@@ -151,7 +151,7 @@ func restoreCommand(c Command) int {
 	if c.Flag.Arg(0) != "-" {
 		fd, err := os.Open(c.Flag.Arg(0))
 		if err != nil {
-			log.Fatal("Error opening tar archive: %s", err)
+			log.Fatalf("Error opening tar archive: %s", err)
 		}
 		err = RestoreTar(Cluster.HostPorts(), fd)
 	} else {

--- a/cmd/bucky/tar.go
+++ b/cmd/bucky/tar.go
@@ -90,7 +90,7 @@ func writeTar(workOut chan *metrics.MetricData, wg *sync.WaitGroup) {
 
 	err := tw.Close()
 	if err != nil {
-		log.Fatal("Error closing tar archive: %s", err)
+		log.Fatalf("Error closing tar archive: %s", err)
 	}
 
 	wg.Done()

--- a/datapoints.go
+++ b/datapoints.go
@@ -2,11 +2,10 @@ package buckytools
 
 import (
 	"math"
-	"sort"
 	"time"
-)
 
-import "github.com/go-graphite/buckytools/whisper"
+	"github.com/go-graphite/go-whisper"
+)
 
 // FindValidDataPoints does a backwards walk through time to examine the
 // highest resolution data for each archive / time period.  We collect valid
@@ -17,12 +16,10 @@ import "github.com/go-graphite/buckytools/whisper"
 func FindValidDataPoints(wsp *whisper.Whisper) ([]*whisper.TimeSeriesPoint, int, error) {
 	points := make([]*whisper.TimeSeriesPoint, 0)
 	count := 0
-	retentions := whisper.RetentionsByPrecision{wsp.Retentions()}
-	sort.Sort(retentions)
 
 	start := int(time.Now().Unix())
 	from := 0
-	for _, r := range retentions.Iterator() {
+	for _, r := range wsp.Retentions() {
 		from = int(time.Now().Unix()) - r.MaxRetention()
 
 		ts, err := wsp.Fetch(from, start)
@@ -30,7 +27,7 @@ func FindValidDataPoints(wsp *whisper.Whisper) ([]*whisper.TimeSeriesPoint, int,
 			return make([]*whisper.TimeSeriesPoint, 0, 0), 0, err
 		}
 		count = count + len(ts.Values())
-		for _, v := range ts.Points() {
+		for _, v := range ts.PointPointers() {
 			if !math.IsNaN(v.Value) {
 				points = append(points, v)
 			}

--- a/fill/fill_test.go
+++ b/fill/fill_test.go
@@ -9,9 +9,9 @@ import (
 	"os/exec"
 	"testing"
 	"time"
-)
 
-import "github.com/go-graphite/buckytools/whisper"
+	"github.com/go-graphite/go-whisper"
+)
 
 func whisperCreateData(path string, ts []*whisper.TimeSeriesPoint) error {
 	os.Remove(path) // Don't care if it fails
@@ -162,7 +162,7 @@ func fetchFromFile(path string) ([]*whisper.TimeSeriesPoint, error) {
 		return tsp, err
 	}
 
-	return ts.Points(), nil
+	return ts.PointPointers(), nil
 }
 
 func simulateFill(a, b []*whisper.TimeSeriesPoint) []*whisper.TimeSeriesPoint {
@@ -378,7 +378,7 @@ func TestTwoArchives(t *testing.T) {
 	}
 
 	if len(goFill) != len(pythonFill) {
-		t.Fatalf("length mismatch, python=%v, go=%v, expected=%v", len(goFill), len(pythonFill))
+		t.Fatalf("length mismatch, python=%v, go=%v", len(goFill), len(pythonFill))
 	}
 
 	// Now try to print out a table of C, D, Python, Go, Simu

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -833,7 +833,7 @@ type DataPoints []dataPoint
 
 func (dps DataPoints) Len() int { return len(dps) }
 func (dps DataPoints) Less(i, j int) bool {
-	if dps[i].interval == 0 || dps[i].interval == 0 {
+	if dps[i].interval == 0 || dps[j].interval == 0 {
 		return false
 	}
 	return dps[i].interval < dps[j].interval


### PR DESCRIPTION
This changes doesn't change buckytools functionality. 
The reason behind this change to pave the way for supporting compressed format in buckytools.

(modify command is still using the old whisper library in this repo, but it's not a core functionality supported by buckytools. So I haven't migrate the changes yet. Shouldn't be a blocker.)