### PR TITLE
Fix package builds of go-graphite/buckytools

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 export DH_OPTIONS
-export DH_GOPKG := github.com/jjneely/buckytools
+export DH_GOPKG := github.com/go-graphite/buckytools
 
 DEBPKGNAME ?= $(shell dpkg-parsechangelog | sed -n -e 's/^Source: //p')
 BUILDDIR   := $(shell perl -w -MDebian::Debhelper::Buildsystem::golang -e \


### PR DESCRIPTION
Similar to #3, except fixes when building from `fakeroot debian/rules binary`.