### PR TITLE
rebalance: new offload feature/flag to speed up rebalancing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,17 @@ findhash:
 gentestmetrics:
 	go build -mod vendor ./cmd/$@
 
+# To keep testdata after running test for debugging, run the following command:
+#
+# 	make test REBALANCE_FLAGS=-keep-testdata
+#
+test: clean bucky buckyd
+	go run -mod vendor testing/rebalance.go $(REBALANCE_FLAGS)
+	go run -mod vendor testing/copy.go $(COPY_FLAGS)
+
+clean_test:
+	rm -rf testdata_rebalance_*
+	rm -rf testdata_copy_*
+
 clean:
 	$(RM) $(targets)

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ use the `-no-delete` flag.  The default behavior is to move metrics and
 delete the source after a successful copy.
 
     $ bucky rebalance -h graphite010-g5:4242 \
-        -w 25 2>&1 | tee rebalance.log
+        -w 5 2>&1 | tee rebalance.log
 
 Discover the exact storage used by a set of metrics:
 
@@ -167,12 +167,17 @@ Make a backup of all of the metrics in the `carbon` namespace.  Using the
 [pigz][2] parallel gzip compression tool.  (Normal gzip would otherwise bottleneck
 the process.)
 
-    $ bucky tar -w 25 -r '^carbon\.' | pigz > filename.tar
+    $ bucky tar -w 5 -r '^carbon\.' | pigz > filename.tar
 
 Backfill or rename metrics with a JSON hash of old name to new name.  This
 does not delete the source metric.  It is a copy/fill operation.
 
-    $ bucky backfill -w 25 foo.json
+    $ bucky backfill -w 5 foo.json
+
+Offload backfilling to data nodes. This should be more performant as it saves one
+round trip by asking data nodes to copy data directly between each other.
+
+    $ bucky backfill -w 5  -h graphite010-g5:4242 -w 5 -offload
 
 Find inconsistent metrics or metrics that are in the wrong place in the
 cluster according to the hashring:

--- a/cmd/bucky/backfill.go
+++ b/cmd/bucky/backfill.go
@@ -71,7 +71,7 @@ func backfillWorker(workIn chan *MigrateWork, wg *sync.WaitGroup) {
 			continue
 		}
 		metric.Name = work.newName
-		err = PostMetric(work.newLocation, metric)
+		_, err = PostMetric(work.newLocation, metric)
 		if err != nil {
 			// errors already handled
 			workerErrors = true

--- a/cmd/bucky/common.go
+++ b/cmd/bucky/common.go
@@ -51,6 +51,8 @@ func GetHTTP() *http.Client {
 				Timeout: 1 * time.Second,
 			}).Dial,
 			ResponseHeaderTimeout: time.Duration(HttpTimeout) * time.Second,
+			IdleConnTimeout:       10 * time.Minute,
+			MaxIdleConnsPerHost:   300,
 		},
 	}
 

--- a/cmd/bucky/common.go
+++ b/cmd/bucky/common.go
@@ -306,7 +306,7 @@ func PostMetric(server string, metric *MetricData) (*metricHealStats, error) {
 	u.Host, err = SanitizeHostPort(server)
 	if err != nil {
 		log.Printf("Malformed hostname: %s", err)
-		return nil, nil
+		return nil, err
 	}
 
 	buf := bytes.NewBuffer(metric.Data)
@@ -371,7 +371,7 @@ func CopyMetric(src, dst, metric string) (*metricHealStats, error) {
 	u.Host, err = SanitizeHostPort(dst)
 	if err != nil {
 		log.Printf("Malformed hostname: %s", err)
-		return nil, nil
+		return nil, err
 	}
 
 	resp, err := httpClient.PostForm(u.String(), url.Values{
@@ -406,7 +406,7 @@ func CopyMetric(src, dst, metric string) (*metricHealStats, error) {
 	var stats metricHealStats
 	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
 		log.Printf("Failed to retrieve heal stats: %s", err)
-		return nil, nil
+		return nil, err
 	}
 
 	return &stats, nil

--- a/cmd/bucky/common.go
+++ b/cmd/bucky/common.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -293,7 +294,7 @@ func StatRemoteMetric(server, metric string) (*MetricData, error) {
 
 // PostMetric sends a POST request with new metric data to the given server.
 // A post request does a backfill if this metric is already present on disk.
-func PostMetric(server string, metric *MetricData) error {
+func PostMetric(server string, metric *MetricData) (*metricHealStats, error) {
 	var err error
 	httpClient := GetHTTP()
 	u := &url.URL{
@@ -303,18 +304,18 @@ func PostMetric(server string, metric *MetricData) error {
 	u.Host, err = SanitizeHostPort(server)
 	if err != nil {
 		log.Printf("Malformed hostname: %s", err)
-		return nil
+		return nil, nil
 	}
 
 	buf := bytes.NewBuffer(metric.Data)
 	r, err := http.NewRequest("POST", u.String(), buf)
 	if err != nil {
 		log.Printf("Error building request: %s", err)
-		return err
+		return nil, err
 	}
 	statInfo, err := json.Marshal(metric)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	r.Header.Set("X-Metric-Stat", string(statInfo))
 	r.Header.Set("Content-Type", "application/octet-stream")
@@ -327,7 +328,7 @@ func PostMetric(server string, metric *MetricData) error {
 	resp, err := httpClient.Do(r)
 	if err != nil {
 		log.Printf("Error communicating with server: %s", err)
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
@@ -335,10 +336,78 @@ func PostMetric(server string, metric *MetricData) error {
 		msg := fmt.Sprintf("Error reported by server: %s for metric %s",
 			resp.Status, metric.Name)
 		log.Printf("%s", msg)
-		return fmt.Errorf("%s", msg)
+		return nil, fmt.Errorf("%s", msg)
 	}
 
-	return nil
+	var stats metricHealStats
+	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
+		log.Printf("Failed to retrieve heal stats: %s", err)
+		return nil, nil
+	}
+
+	return &stats, nil
+}
+
+var errNotFound = errors.New("metric not found")
+
+type metricHealStats struct {
+	Download int64
+	Dump     int64
+	Fill     int64
+	Compress int64
+	Copy     int64
+}
+
+func CopyMetric(src, dst, metric string) (*metricHealStats, error) {
+	var err error
+	httpClient := GetHTTP()
+	u := &url.URL{
+		Scheme:   "http",
+		Path:     "/metrics/" + metric,
+		RawQuery: "fetch_offload=true",
+	}
+	u.Host, err = SanitizeHostPort(dst)
+	if err != nil {
+		log.Printf("Malformed hostname: %s", err)
+		return nil, nil
+	}
+
+	resp, err := httpClient.PostForm(u.String(), url.Values{
+		"no_encoding": {fmt.Sprintf("%t", NoEncoding)},
+		"server":      {src},
+		"metric":      {metric},
+	})
+	if err != nil {
+		log.Printf("Error communicating with server: %s", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Printf("Error on reading response body: %s", err)
+		}
+		msg := fmt.Sprintf("Error reported by server: %s for metric %s: %s",
+			resp.Status, metric, body)
+		log.Printf("%s", msg)
+
+		// Given that metrics could be periodically removed from storage backend,
+		// A 404 could be hanled differently.
+		if resp.StatusCode == 404 {
+			return nil, errNotFound
+		}
+
+		return nil, fmt.Errorf("%s", msg)
+	}
+
+	var stats metricHealStats
+	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
+		log.Printf("Failed to retrieve heal stats: %s", err)
+		return nil, nil
+	}
+
+	return &stats, nil
 }
 
 // GetSingleHashRing connects to the given server and returns a JSONRingType

--- a/cmd/bucky/common_sync.go
+++ b/cmd/bucky/common_sync.go
@@ -83,14 +83,16 @@ func (ms *metricSyncer) run(jobsd map[string]map[string][]*syncJob) error {
 			// Why src nodes have 1.5x workers: eading data is less
 			// expensive than writing data, so it should be ok for
 			// source node to receive some more reading requests.
-			srcThrottling[src] = make(chan struct{}, ms.flags.workers+ms.flags.workers/2)
-
-			for i := 0; i < ms.flags.workers; i++ {
-				totalWorkers++
-
-				workerWg.Add(1)
-				go ms.sync(jobc, srcThrottling, workerWg)
+			if _, ok := srcThrottling[src]; !ok {
+				srcThrottling[src] = make(chan struct{}, ms.flags.workers+ms.flags.workers/2)
 			}
+		}
+
+		for i := 0; i < ms.flags.workers; i++ {
+			totalWorkers++
+
+			workerWg.Add(1)
+			go ms.sync(jobc, srcThrottling, workerWg)
 		}
 	}
 

--- a/cmd/bucky/common_sync.go
+++ b/cmd/bucky/common_sync.go
@@ -1,0 +1,342 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+type metricSyncer struct {
+	flags struct {
+		workers      int
+		delete       bool
+		noop         bool
+		offloadFetch bool
+		ignore404    bool
+		verbose      bool
+	}
+
+	stat struct {
+		notFound    int
+		copyError   int
+		deleteError int
+
+		time struct {
+			count int64
+			total int64
+
+			download, dump, fill, compress, copy, delete struct {
+				count int64
+				total int64
+			}
+		}
+	}
+}
+
+func newMetricSyncer(delete, noop, offloadFetch, ignore404, verbose bool, workers int) *metricSyncer {
+	var ms metricSyncer
+
+	ms.flags.workers = workers
+	ms.flags.delete = delete
+	ms.flags.noop = noop
+	ms.flags.offloadFetch = offloadFetch
+	ms.flags.ignore404 = ignore404
+	ms.flags.verbose = verbose
+
+	return &ms
+}
+
+func (ms *metricSyncer) restTime() int64 {
+	return atomic.LoadInt64(&ms.stat.time.total) - atomic.LoadInt64(&ms.stat.time.download.total) - atomic.LoadInt64(&ms.stat.time.dump.total) - atomic.LoadInt64(&ms.stat.time.fill.total) - atomic.LoadInt64(&ms.stat.time.compress.total) - atomic.LoadInt64(&ms.stat.time.copy.total) - atomic.LoadInt64(&ms.stat.time.delete.total)
+}
+
+type syncJob struct {
+	srcServer string
+	dstServer string
+	oldName   string
+	newName   string
+}
+
+func (ms *metricSyncer) run(jobsd map[string]map[string][]*syncJob) error {
+	totalJobs := ms.countJobs(jobsd)
+	log.Printf("Syncing %d metrics. Copy offload: %t.", totalJobs, ms.flags.offloadFetch)
+
+	if ms.flags.noop {
+		return errors.New("Halting.  No-op mode enganged.")
+	}
+
+	jobcs := map[string]chan *syncJob{}
+	srcThrottling := map[string]chan struct{}{}
+	workerWg := new(sync.WaitGroup)
+	var totalWorkers int
+	for dst, srcJobs := range jobsd {
+		jobc := make(chan *syncJob, ms.flags.workers)
+		jobcs[dst] = jobc
+
+		for src := range srcJobs {
+			// Why src nodes have 1.5x workers: eading data is less
+			// expensive than writing data, so it should be ok for
+			// source node to receive some more reading requests.
+			srcThrottling[src] = make(chan struct{}, ms.flags.workers+ms.flags.workers/2)
+
+			for i := 0; i < ms.flags.workers; i++ {
+				totalWorkers++
+
+				workerWg.Add(1)
+				go ms.sync(jobc, srcThrottling, workerWg)
+			}
+		}
+	}
+
+	// num of old servers * num of new servers * metric workers
+	log.Printf("Total workers: %d", totalWorkers)
+
+	// Queue up and process work
+	var serverWg sync.WaitGroup
+	var progress int64
+	for dst, jobss := range jobsd {
+		for src, jobs := range jobss {
+			serverWg.Add(1)
+
+			go func(dst, src string, jobs []*syncJob) {
+				jobc := jobcs[dst]
+
+				for _, job := range jobs {
+					job.srcServer = src
+					job.dstServer = dst
+					jobc <- job
+					atomic.AddInt64(&progress, 1)
+				}
+
+				serverWg.Done()
+			}(dst, src, jobs)
+		}
+	}
+
+	progressDone := make(chan struct{})
+	go ms.displayProgressOrExit(totalJobs, &progress, progressDone)
+
+	serverWg.Wait()
+	for _, c := range jobcs {
+		close(c)
+	}
+	workerWg.Wait()
+
+	close(progressDone)
+	time.Sleep(time.Millisecond * 50) // give some time for printing the last progress info
+
+	logbreakdownStat := func(name string, stat *struct{ count, total int64 }) {
+		stotal := atomic.LoadInt64(&stat.total)
+		scount := atomic.LoadInt64(&stat.count)
+
+		ttotal := atomic.LoadInt64(&ms.stat.time.total)
+		tcount := atomic.LoadInt64(&ms.stat.time.count)
+
+		log.Printf("      %s: %s (%.2f%%) count: %d (%.2f%%)", name, time.Duration(stotal), 100*float64(stotal)/float64(ttotal), scount, 100*float64(scount)/float64(tcount))
+	}
+
+	log.Println("Sync completed:")
+	log.Printf("  404 Counter: %d", ms.stat.notFound)
+	log.Printf("  Copy failure: %d", ms.stat.copyError)
+	log.Printf("  Delete failure: %d", ms.stat.deleteError)
+	log.Printf("  Time Stats:")
+	log.Printf("    Total Sync: %s", time.Duration(ms.stat.time.total))
+	logbreakdownStat("Download", &ms.stat.time.download)
+	logbreakdownStat("Dump", &ms.stat.time.dump)
+	logbreakdownStat("Fill", &ms.stat.time.fill)
+	logbreakdownStat("Compress", &ms.stat.time.compress)
+	logbreakdownStat("Copy", &ms.stat.time.copy)
+	logbreakdownStat("Delete", &ms.stat.time.delete)
+	log.Printf("      Rest: %s (%.2f%%)", time.Duration(ms.restTime()), float64(100*ms.restTime())/float64(atomic.LoadInt64(&ms.stat.time.total)))
+
+	if (!ignore404 && ms.stat.notFound > 0) || ms.stat.copyError > 0 || ms.stat.deleteError > 0 {
+		log.Println("Errors are present in sync.")
+		return fmt.Errorf("Errors present.")
+	}
+
+	return nil
+}
+
+// countMap returns the number of metrics in a server -> metrics mapping
+func (ms *metricSyncer) countJobs(jobsd map[string]map[string][]*syncJob) int {
+	c := 0
+	for _, jobss := range jobsd {
+		for _, jobs := range jobss {
+			c = c + len(jobs)
+		}
+	}
+	return c
+}
+
+func (ms *metricSyncer) sync(jobc chan *syncJob, srcThrottling map[string]chan struct{}, wg *sync.WaitGroup) {
+	for job := range jobc {
+		func() {
+			src, dst := job.srcServer, job.dstServer
+
+			srcThrottling[src] <- struct{}{}
+
+			syncStart := time.Now()
+			defer func() {
+				atomic.AddInt64(&ms.stat.time.count, 1)
+				atomic.AddInt64(&ms.stat.time.total, int64(time.Since(syncStart)))
+
+				<-srcThrottling[src]
+			}()
+
+			if ms.flags.verbose {
+				log.Printf("Relocating [%s] %s => [%s] %s  Delete Source: %t",
+					src, job.oldName,
+					dst, job.newName, ms.flags.delete)
+			}
+
+			var mhstats *metricHealStats
+			if ms.flags.offloadFetch {
+				var err error
+				mhstats, err = CopyMetric(src, dst, job.oldName)
+				if err != nil {
+					// errors already loggged in the func
+					if errors.Is(err, errNotFound) {
+						ms.stat.notFound++
+					} else {
+						ms.stat.copyError++
+					}
+
+					return
+				}
+			} else {
+				metric, err := GetMetricData(src, job.oldName)
+				if err != nil {
+					// errors already loggged in the func
+					if errors.Is(err, errNotFound) {
+						ms.stat.notFound++
+					} else {
+						ms.stat.copyError++
+					}
+
+					return
+				}
+				metric.Name = job.newName
+				mhstats, err = PostMetric(dst, metric)
+				if err != nil {
+					// errors already loggged in the func
+					if errors.Is(err, errNotFound) {
+						ms.stat.notFound++
+					} else {
+						ms.stat.copyError++
+					}
+
+					return
+				}
+			}
+
+			if mhstats != nil {
+				if mhstats.Download > 0 {
+					atomic.AddInt64(&ms.stat.time.download.count, 1)
+					atomic.AddInt64(&ms.stat.time.download.total, mhstats.Download)
+				}
+				if mhstats.Dump > 0 {
+					atomic.AddInt64(&ms.stat.time.dump.count, 1)
+					atomic.AddInt64(&ms.stat.time.dump.total, mhstats.Dump)
+				}
+				if mhstats.Fill > 0 {
+					atomic.AddInt64(&ms.stat.time.fill.count, 1)
+					atomic.AddInt64(&ms.stat.time.fill.total, mhstats.Fill)
+				}
+				if mhstats.Compress > 0 {
+					atomic.AddInt64(&ms.stat.time.compress.count, 1)
+					atomic.AddInt64(&ms.stat.time.compress.total, mhstats.Compress)
+				}
+				if mhstats.Copy > 0 {
+					atomic.AddInt64(&ms.stat.time.copy.count, 1)
+					atomic.AddInt64(&ms.stat.time.copy.total, mhstats.Copy)
+				}
+			}
+
+			// We only delete if there are no errors present
+			if ms.flags.delete {
+				deleteStart := time.Now()
+
+				err := DeleteMetric(src, job.oldName)
+				if err != nil {
+					// errors already loggged in the func
+					ms.stat.deleteError++
+				}
+
+				atomic.AddInt64(&ms.stat.time.delete.count, 1)
+				atomic.AddInt64(&ms.stat.time.delete.total, int64(time.Since(deleteStart)))
+			}
+		}()
+	}
+
+	wg.Done()
+}
+
+func (ms *metricSyncer) displayProgressOrExit(total int, progress *int64, progressDone chan struct{}) {
+	var start = time.Now().Unix()
+	var ptime = time.Now().Unix()
+	var pprogress int64
+	var exit, forceExit bool
+	var ticker = time.NewTicker(time.Second * 10)
+	defer ticker.Stop()
+
+	manualQuit := make(chan os.Signal, 1)
+	signal.Notify(manualQuit, syscall.SIGUSR1)
+
+	for {
+		select {
+		case <-ticker.C:
+		case <-manualQuit:
+			forceExit = true
+		case <-progressDone:
+			exit = true
+		}
+
+		now := time.Now().Unix()
+
+		deltaCurrent := now - ptime
+		if deltaCurrent == 0 {
+			deltaCurrent = 1
+		}
+
+		deltaAll := now - start
+		if deltaAll == 0 {
+			deltaAll = 1
+		}
+
+		cprogress := atomic.LoadInt64(progress)
+		pdiff := cprogress - pprogress
+		if pdiff == 0 {
+			pdiff = 1
+		}
+
+		remaining := float64(int64(total) - cprogress)
+		speedAll := float64(cprogress) / float64(deltaAll)
+		speedCurrent := float64(pdiff) / float64(deltaCurrent)
+
+		log.Printf(
+			"Progress %d / %d: %.2f%%  Metrics/second: %.2f  Delete: %t ETA_All/Current: %s/%s",
+			cprogress, total,
+			100*float64(cprogress)/float64(total),
+			float64(cprogress-pprogress)/float64(deltaCurrent),
+			ms.flags.delete,
+			time.Duration(remaining/speedAll)*time.Second,
+			time.Duration(remaining/speedCurrent)*time.Second,
+		)
+
+		pprogress = cprogress
+		ptime = now
+
+		if exit {
+			return
+		} else if forceExit {
+			log.Printf("Received SIGUSR1, exiting.")
+			os.Exit(1)
+		}
+	}
+}

--- a/cmd/bucky/copy.go
+++ b/cmd/bucky/copy.go
@@ -1,0 +1,59 @@
+package main
+
+import "log"
+
+type copyCommand struct {
+	src, dst  string
+	listForce bool
+	metricSyncer
+}
+
+func init() {
+	usage := "[options] [additional buckyd servers...]"
+	short := "Copy metrics from one server to another."
+	long := `TODO`
+
+	var copyCmd copyCommand
+
+	c := NewCommand(copyCmd.do, "copy", usage, short, long)
+	SetupCommon(c)
+	SetupHostname(c)
+	SetupSingle(c)
+
+	// c.Flag.BoolVar(&doDelete, "delete", false, "Delete metrics after moving them.")
+	c.Flag.StringVar(&copyCmd.src, "src", "", "Source host to copy metrics from.")
+	c.Flag.StringVar(&copyCmd.dst, "dst", "", "Destination host to copy metrics to.")
+	c.Flag.BoolVar(&copyCmd.flags.noop, "no-op", false, "Do not alter metrics and print report.")
+	c.Flag.IntVar(&copyCmd.flags.workers, "w", 5, "Downloader threads.")
+	c.Flag.IntVar(&copyCmd.flags.workers, "workers", 5, "Downloader threads.")
+	c.Flag.BoolVar(&copyCmd.listForce, "f", false, "Force the remote daemons to rebuild their cache.")
+	c.Flag.BoolVar(&copyCmd.flags.offloadFetch, "offload", false, "Offload metric data fetching to data nodes.")
+	c.Flag.BoolVar(&copyCmd.flags.ignore404, "ignore404", false, "Do not treat 404 as errors.")
+}
+
+// rebalanceCommand runs this subcommand.
+func (cc *copyCommand) do(c Command) int {
+	cc.flags.verbose = Verbose
+
+	if cc.src == "" || cc.dst == "" {
+		log.Printf("Please specify -src and -dst.")
+		return 1
+	}
+
+	metricsMap, err := ListAllMetrics([]string{cc.src}, cc.listForce)
+	if err != nil {
+		log.Printf("Failed to retrieve metrics: %s", err)
+		return 1
+	}
+
+	log.Printf("Number of metrics to copy: %d", len(metricsMap[cc.src]))
+
+	jobs := map[string]map[string][]*syncJob{cc.dst: {}}
+	for _, m := range metricsMap[cc.src] {
+		jobs[cc.dst][cc.src] = append(jobs[cc.dst][cc.src], &syncJob{oldName: m, newName: m})
+	}
+
+	cc.run(jobs)
+
+	return 0
+}

--- a/cmd/bucky/restore.go
+++ b/cmd/bucky/restore.go
@@ -9,9 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-)
 
-import . "github.com/go-graphite/buckytools/metrics"
+	. "github.com/go-graphite/buckytools/metrics"
+)
 
 var tarPrefix string
 
@@ -65,7 +65,7 @@ func restoreTarWorker(workIn chan *MetricData, servers []string, wg *sync.WaitGr
 			continue
 		}
 		log.Printf("Uploading %s => %s", work.Name, server)
-		err := PostMetric(server, work)
+		_, err := PostMetric(server, work)
 		if err != nil {
 			workerErrors = true
 		}

--- a/hashing/hashing.go
+++ b/hashing/hashing.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+
 	//"log"
 	//"os"
 	"strconv"

--- a/testing/copy.go
+++ b/testing/copy.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"crypto/rand"
+	"flag"
+	"fmt"
+	"log"
+	"math"
+	mrand "math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-graphite/buckytools/hashing"
+	"github.com/go-graphite/go-whisper"
+)
+
+func main() {
+	// 1. populate metrics
+	// 2. start three buckyd instances
+	// 3. run rebalance
+
+	keepTestData := flag.Bool("keep-testdata", false, "keep test data after test")
+	flag.Parse()
+
+	log.SetFlags(log.Lshortfile)
+
+	var failed bool
+	defer func() {
+		if failed {
+			os.Exit(1)
+		}
+	}()
+
+	testDir, err := os.MkdirTemp("./", "testdata_copy_*")
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if !*keepTestData {
+			os.RemoveAll(testDir)
+		}
+	}()
+
+	log0, err := os.Create(filepath.Join(testDir, "server0.log"))
+	if err != nil {
+		panic(err)
+	}
+	log1, err := os.Create(filepath.Join(testDir, "server1.log"))
+	if err != nil {
+		panic(err)
+	}
+	log2, err := os.Create(filepath.Join(testDir, "server2.log"))
+	if err != nil {
+		panic(err)
+	}
+	copyLog, err := os.Create(filepath.Join(testDir, "copy.log"))
+	if err != nil {
+		panic(err)
+	}
+
+	var (
+		server0 = hashing.Node{Server: "localhost", Port: 40000, Instance: "server0"}
+		server1 = hashing.Node{Server: "localhost", Port: 40001, Instance: "server1"}
+		server2 = hashing.Node{Server: "localhost", Port: 40002, Instance: "server2"}
+	)
+
+	if err := os.MkdirAll(filepath.Join(testDir, "server0"), 0755); err != nil {
+		panic(err)
+	}
+	if err := os.MkdirAll(filepath.Join(testDir, "server1"), 0755); err != nil {
+		panic(err)
+	}
+	if err := os.MkdirAll(filepath.Join(testDir, "server2"), 0755); err != nil {
+		panic(err)
+	}
+
+	cmd0 := exec.Command("./buckyd", "-hash", "jump_fnv1a", "-b", nodeStr(server0), "-node", server0.Server, "-prefix", filepath.Join(testDir, "server0"), "-replicas", "1", "-sparse", nodeStr(server0), nodeStr(server1), nodeStr(server2))
+	cmd0.Stdout = log0
+	cmd0.Stderr = log0
+	if err := cmd0.Start(); err != nil {
+		panic(err)
+	}
+
+	cmd1 := exec.Command("./buckyd", "-hash", "jump_fnv1a", "-b", nodeStr(server1), "-node", server1.Server, "-prefix", filepath.Join(testDir, "server1"), "-replicas", "1", "-sparse", nodeStr(server0), nodeStr(server1), nodeStr(server2))
+	cmd1.Stdout = log1
+	cmd1.Stderr = log1
+	if err := cmd1.Start(); err != nil {
+		panic(err)
+	}
+
+	cmd2 := exec.Command("./buckyd", "-hash", "jump_fnv1a", "-b", nodeStr(server2), "-node", server2.Server, "-prefix", filepath.Join(testDir, "server2"), "-replicas", "1", "-sparse", nodeStr(server0), nodeStr(server1), nodeStr(server2))
+	cmd2.Stdout = log2
+	cmd2.Stderr = log2
+	if err := cmd2.Start(); err != nil {
+		panic(err)
+	}
+	defer func() {
+		cmd0.Process.Kill()
+		cmd1.Process.Kill()
+		cmd2.Process.Kill()
+	}()
+
+	mrand.Seed(time.Now().Unix())
+
+	var wg sync.WaitGroup
+	var totalFiles = 100
+	wg.Add(totalFiles)
+
+	var metrics = map[string]hashing.Node{}
+
+	var ring = hashing.NewJumpHashRing(3)
+	ring.AddNode(server0)
+	ring.AddNode(server1)
+
+	filesStart := time.Now()
+	for i := 0; i < totalFiles; i++ {
+		b := make([]byte, 32)
+		_, err := rand.Read(b)
+		if err != nil {
+			panic(fmt.Errorf("failed to read random bytes: %s", err))
+		}
+		rets, err := whisper.ParseRetentionDefs("1s:3h,10s:3d,1m:31d")
+		if err != nil {
+			panic(err)
+		}
+		metric := fmt.Sprintf("metric_%x", b)
+		node := ring.GetNode(metric)
+		metrics[metric] = node
+		file, err := whisper.Create(filepath.Join(testDir, node.Instance, metric+".wsp"), rets, whisper.Sum, 0)
+		if err != nil {
+			panic(err)
+		}
+		go func() {
+			var points []*whisper.TimeSeriesPoint
+			var now = int(time.Now().Unix()) - 1800
+			for i := 0; i < 1800; i++ {
+				points = append(points, &whisper.TimeSeriesPoint{Time: now + i, Value: mrand.Float64()})
+			}
+			if err := file.UpdateMany(points); err != nil {
+				panic(err)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	log.Printf("finished creating whisper files. took %s\n", time.Since(filesStart))
+
+	time.Sleep(time.Second * 3)
+	rebalanceStart := time.Now()
+	copyCmd := exec.Command("./bucky", "copy", "-f", "-offload", "-src", nodeStr(server0), "-dst", nodeStr(server2), "-w", "3", "-ignore404")
+
+	copyCmd.Stdout = copyLog
+	copyCmd.Stderr = copyLog
+
+	log.Printf("copyCmd.String() = %+v\n", copyCmd.String())
+	if err := copyCmd.Run(); err != nil {
+		log.Printf("failed to run rebalance command: %s", err)
+		failed = true
+		return
+	}
+
+	log.Printf("finished copying. took %s\n", time.Since(rebalanceStart))
+
+	files0, err := os.ReadDir(filepath.Join(testDir, "server0"))
+	if err != nil {
+		panic(err)
+	}
+	files2, err := os.ReadDir(filepath.Join(testDir, "server2"))
+	if err != nil {
+		panic(err)
+	}
+	if len(files0) != len(files2) {
+		log.Printf("file count doesn't match on server0 (%d) and server2 (%d)", len(files0), len(files2))
+		failed = true
+		return
+	}
+
+	log.Printf("%d files relocated.", len(files0))
+
+	var inconsistentMetrics []string
+	for _, m := range files0 {
+		newf, err := whisper.Open(filepath.Join(testDir, "server2", m.Name()))
+		if err != nil {
+			panic(err)
+		}
+		oldf, err := whisper.Open(filepath.Join(testDir, "server0", m.Name()))
+		if err != nil {
+			panic(err)
+		}
+		nrets := newf.Retentions()
+		orets := oldf.Retentions()
+		if !reflect.DeepEqual(nrets, orets) {
+			log.Printf("rention policy not equal:\n  new: %#v\n  old: %#v\n", nrets, orets)
+		}
+		now := int(time.Now().Unix())
+		for _, ret := range nrets {
+			ndata, err := newf.Fetch(now-ret.MaxRetention(), now)
+			if err != nil {
+				panic(err)
+			}
+			odata, err := oldf.Fetch(now-ret.MaxRetention(), now)
+			if err != nil {
+				panic(err)
+			}
+			if ndata == nil {
+				log.Printf("failed to retrieve data from file %s\n", newf.File().Name())
+				continue
+			}
+			if odata == nil {
+				log.Printf("failed to retrieve data from file %s\n", newf.File().Name())
+				continue
+			}
+
+			var count int
+			var npoints = ndata.Points()
+			var opoints = odata.Points()
+			for i, opoint := range opoints {
+				if !math.IsNaN(opoint.Value) && !math.IsNaN(npoints[i].Value) && opoint != npoints[i] {
+					count++
+					log.Printf("opoints = %+v\n", opoints[i])
+					log.Printf("npoints = %+v\n", npoints[i])
+
+					if len(inconsistentMetrics) == 0 || inconsistentMetrics[len(inconsistentMetrics)-1] != m.Name() {
+						inconsistentMetrics = append(inconsistentMetrics, m.Name())
+					}
+				}
+			}
+
+			if count > 0 {
+				log.Printf("metric %s %s: %d points not equal", m.Name(), ret, count)
+			}
+		}
+
+		newf.Close()
+		oldf.Close()
+	}
+
+	if len(inconsistentMetrics) > 0 {
+		log.Printf("%d copied metrics not matching original metrics: %s", len(inconsistentMetrics), strings.Join(inconsistentMetrics, ","))
+		failed = true
+		return
+	} else {
+		log.Printf("metrics are copied properly.")
+	}
+}
+
+func nodeStr(n hashing.Node) string { return fmt.Sprintf("%s:%d", n.Server, n.Port) }

--- a/testing/rebalance.go
+++ b/testing/rebalance.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"crypto/rand"
+	"flag"
+	"fmt"
+	"log"
+	"math"
+	mrand "math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-graphite/buckytools/hashing"
+	"github.com/go-graphite/go-whisper"
+)
+
+func main() {
+	// 1. populate metrics
+	// 2. start three buckyd instances
+	// 3. run rebalance
+
+	keepTestData := flag.Bool("keep-testdata", false, "keep test data after test")
+	flag.Parse()
+
+	log.SetFlags(log.Lshortfile)
+
+	var failed bool
+	defer func() {
+		if failed {
+			os.Exit(1)
+		}
+	}()
+
+	testDir, err := os.MkdirTemp("./", "testdata_rebalance_*")
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if !*keepTestData {
+			os.RemoveAll(testDir)
+		}
+	}()
+
+	log0, err := os.Create(filepath.Join(testDir, "server0.log"))
+	if err != nil {
+		panic(err)
+	}
+	log1, err := os.Create(filepath.Join(testDir, "server1.log"))
+	if err != nil {
+		panic(err)
+	}
+	log2, err := os.Create(filepath.Join(testDir, "server2.log"))
+	if err != nil {
+		panic(err)
+	}
+	rebalanceLog, err := os.Create(filepath.Join(testDir, "rebalance.log"))
+	if err != nil {
+		panic(err)
+	}
+
+	var (
+		server0 = hashing.Node{Server: "localhost", Port: 40000, Instance: "server0"}
+		server1 = hashing.Node{Server: "localhost", Port: 40001, Instance: "server1"}
+		server2 = hashing.Node{Server: "localhost", Port: 40002, Instance: "server2"}
+	)
+
+	if err := os.MkdirAll(filepath.Join(testDir, "server0"), 0755); err != nil {
+		panic(err)
+	}
+	if err := os.MkdirAll(filepath.Join(testDir, "server1"), 0755); err != nil {
+		panic(err)
+	}
+	if err := os.MkdirAll(filepath.Join(testDir, "server2"), 0755); err != nil {
+		panic(err)
+	}
+
+	cmd0 := exec.Command("./buckyd", "-hash", "jump_fnv1a", "-b", nodeStr(server0), "-node", server0.Server, "-prefix", filepath.Join(testDir, "server0"), "-replicas", "1", "-sparse", nodeStr(server0), nodeStr(server1), nodeStr(server2))
+	cmd0.Stdout = log0
+	cmd0.Stderr = log0
+	if err := cmd0.Start(); err != nil {
+		panic(err)
+	}
+
+	cmd1 := exec.Command("./buckyd", "-hash", "jump_fnv1a", "-b", nodeStr(server1), "-node", server1.Server, "-prefix", filepath.Join(testDir, "server1"), "-replicas", "1", "-sparse", nodeStr(server0), nodeStr(server1), nodeStr(server2))
+	cmd1.Stdout = log1
+	cmd1.Stderr = log1
+	if err := cmd1.Start(); err != nil {
+		panic(err)
+	}
+
+	cmd2 := exec.Command("./buckyd", "-hash", "jump_fnv1a", "-b", nodeStr(server2), "-node", server2.Server, "-prefix", filepath.Join(testDir, "server2"), "-replicas", "1", "-sparse", nodeStr(server0), nodeStr(server1), nodeStr(server2))
+	cmd2.Stdout = log2
+	cmd2.Stderr = log2
+	if err := cmd2.Start(); err != nil {
+		panic(err)
+	}
+	defer func() {
+		cmd0.Process.Kill()
+		cmd1.Process.Kill()
+		cmd2.Process.Kill()
+	}()
+
+	mrand.Seed(time.Now().Unix())
+
+	var wg sync.WaitGroup
+	var totalFiles = 100
+	wg.Add(totalFiles)
+
+	var metrics = map[string]hashing.Node{}
+
+	var ring = hashing.NewJumpHashRing(3)
+	ring.AddNode(server0)
+	ring.AddNode(server1)
+
+	filesStart := time.Now()
+	for i := 0; i < totalFiles; i++ {
+		b := make([]byte, 32)
+		_, err := rand.Read(b)
+		if err != nil {
+			panic(fmt.Errorf("failed to read random bytes: %s", err))
+		}
+		rets, err := whisper.ParseRetentionDefs("1s:3h,10s:3d,1m:31d")
+		if err != nil {
+			panic(err)
+		}
+		metric := fmt.Sprintf("metric_%x", b)
+		node := ring.GetNode(metric)
+		metrics[metric] = node
+		file, err := whisper.Create(filepath.Join(testDir, node.Instance, metric+".wsp"), rets, whisper.Sum, 0)
+		if err != nil {
+			panic(err)
+		}
+		go func() {
+			var points []*whisper.TimeSeriesPoint
+			var now = int(time.Now().Unix()) - 1800
+			for i := 0; i < 1800; i++ {
+				points = append(points, &whisper.TimeSeriesPoint{Time: now + i, Value: mrand.Float64()})
+			}
+			if err := file.UpdateMany(points); err != nil {
+				panic(err)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	log.Printf("finished creating whisper files. took %s\n", time.Since(filesStart))
+
+	time.Sleep(time.Second * 3)
+	rebalanceStart := time.Now()
+	rebalanceCmd := exec.Command("./bucky", "rebalance", "-f", "-h", nodeStr(server0), "-offload", "-w", "3", "-ignore404")
+
+	rebalanceCmd.Stdout = rebalanceLog
+	rebalanceCmd.Stderr = rebalanceLog
+
+	log.Printf("rebalanceCmd.String() = %+v\n", rebalanceCmd.String())
+	if err := rebalanceCmd.Run(); err != nil {
+		log.Printf("failed to run rebalance command: %s", err)
+		failed = true
+		return
+	}
+
+	log.Printf("finished rebalancing. took %s\n", time.Since(rebalanceStart))
+
+	files, err := os.ReadDir(filepath.Join(testDir, "server2"))
+	if err != nil {
+		panic(err)
+	}
+	if len(files) == 0 {
+		log.Printf("failed to rebalance cluster: 0 files are relocated.")
+		failed = true
+		return
+	}
+
+	log.Printf("%d files relocated.", len(files))
+
+	var inconsistentMetrics []string
+	for _, m := range files {
+		newf, err := whisper.Open(filepath.Join(testDir, "server2", m.Name()))
+		if err != nil {
+			panic(err)
+		}
+		oldf, err := whisper.Open(filepath.Join(testDir, metrics[strings.TrimSuffix(m.Name(), ".wsp")].Instance, m.Name()))
+		if err != nil {
+			panic(err)
+		}
+		nrets := newf.Retentions()
+		orets := oldf.Retentions()
+		if !reflect.DeepEqual(nrets, orets) {
+			log.Printf("rention policy not equal:\n  new: %#v\n  old: %#v\n", nrets, orets)
+		}
+		now := int(time.Now().Unix())
+		for _, ret := range nrets {
+			ndata, err := newf.Fetch(now-ret.MaxRetention(), now)
+			if err != nil {
+				panic(err)
+			}
+			odata, err := oldf.Fetch(now-ret.MaxRetention(), now)
+			if err != nil {
+				panic(err)
+			}
+			if ndata == nil {
+				log.Printf("failed to retrieve data from file %s\n", newf.File().Name())
+				continue
+			}
+			if odata == nil {
+				log.Printf("failed to retrieve data from file %s\n", newf.File().Name())
+				continue
+			}
+
+			var count int
+			var npoints = ndata.Points()
+			var opoints = odata.Points()
+			for i, opoint := range opoints {
+				if !math.IsNaN(opoint.Value) && !math.IsNaN(npoints[i].Value) && opoint != npoints[i] {
+					count++
+					log.Printf("opoints = %+v\n", opoints[i])
+					log.Printf("npoints = %+v\n", npoints[i])
+
+					if len(inconsistentMetrics) == 0 || inconsistentMetrics[len(inconsistentMetrics)-1] != m.Name() {
+						inconsistentMetrics = append(inconsistentMetrics, m.Name())
+					}
+				}
+			}
+
+			if count > 0 {
+				log.Printf("metric %s %s: %d points not equal", m.Name(), ret, count)
+			}
+		}
+
+		newf.Close()
+		oldf.Close()
+	}
+
+	if len(inconsistentMetrics) > 0 {
+		log.Printf("%d rebalanced metrics not matching original metrics: %s", len(inconsistentMetrics), strings.Join(inconsistentMetrics, ","))
+		failed = true
+		return
+	} else {
+		log.Printf("metrics are rebalanced properly.")
+	}
+}
+
+func nodeStr(n hashing.Node) string { return fmt.Sprintf("%s:%d", n.Server, n.Port) }


### PR DESCRIPTION
The current buckytools rebalance implementation works as folows:

1. List all metrics.
2. Recalculate metric new location.
3. Copying inconsistent whisper files one by one from storage node (where buckyd runs) to control node (where bucky-rebalance runs).

The following improvements are done in this commit:

1. Offload data fetching to storage nodes, instead of fetching metrics from one node and then reposting it to another node. This would save one round trip of syncing data, in theory, we can reduce half the traffic send over the wire during rebalancing. This could be enabled with -offload flag.
2. New threading/concurrent model. Before, the total number of workers are global. In the new model, the -workers N flag allocates N gorouttines for write nodes, and 1.5 * N goroutines for read nodes. This makes it easier to control how fast we can get things rebalanced or copied.
3. New copy command, this command direclty copies metrics from one storage node to another: bucky copy -f -offload -src localhost:40000 -dst localhost:40002 -w 3 -ignore404
4. new flag -ignore404 in bucky rebance command: for storage nodes that deletes metrics from time to time, it is expected to run into 404 when rebalancing/copying metrics. This flag allows bucky to treat 404 as non-errors.
5. New reporting stats at the end of job.


The current model:

```
+----------+             +-------------+             +-----------+
|          | whisper file|             |whisper file |           |
| go-carbon| ----------> | bucky       | ----------> | go-carbon |
|   node 1 |             | control node|             |   node 2  |
| (buckyd) |             |             |             |  (buckyd) |
+----------+             +-------------+             +-----------+
```

A new syncing model:

```
                                      +--------------------+
                                      | bucky control node |
                                      +--------------------+
                                                 |
                                                 |
                                         send sync command
                                                 |
                                                 |
                                                 V
+------------------+     whisper file      +------------------+
| go-carbon node 1 |---------------------> | go-carbon node 2 |
|     (buckyd)     |                       |     (buckyd)     |
+------------------+                       +------------------+
```