### PR TITLE
rebalance: use -metrics-per-second when resetting sync speed with health check

### DIFF
--- a/buckytools.go
+++ b/buckytools.go
@@ -2,7 +2,7 @@ package buckytools
 
 const (
 	// Buckytools suite version
-	Version = "0.4.2"
+	Version = "0.5.2"
 )
 
 // SupportedHashTypes is the string identifiers of the hashing algorithms

--- a/cmd/bucky/common_sync.go
+++ b/cmd/bucky/common_sync.go
@@ -492,11 +492,11 @@ func (ms *metricSyncer) newGoCarbonState(addr string, speedUpInterval int) *goCa
 		for {
 			select {
 			case <-state.fastReset:
-				atomic.StoreInt64(&state.metricsPerSecond, 1)
+				atomic.StoreInt64(&state.metricsPerSecond, mps)
 				speed.Reset(time.Second / time.Duration(state.metricsPerSecond))
 			case <-speedUp.C:
 				if ms.isGoCarbonOverload(state) { // overload check
-					atomic.StoreInt64(&state.metricsPerSecond, 1)
+					atomic.StoreInt64(&state.metricsPerSecond, mps)
 				} else if !ms.flags.noRandomEasing &&
 					atomic.LoadInt64(&state.metricsPerSecond) >= 30 &&
 					rand.Intn(10) <= 2 { // random easing


### PR DESCRIPTION
Before this change, if go-carbon health check is enabled, when go-carbon cache.size overflows, buckytools
reset sync speed to 1 metrics-per-second and there is no way to adjust it. This is not ideal if a go-carbon
box always has cache.size limit over the safety threshold due to file system fragmentation or aging ssd.

With this change, it allows to have an adjustable minimum sync speed.