### PR TITLE
buckytools: revert custom peer port changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,15 +33,31 @@ gentestmetrics:
 #
 # 	make test REBALANCE_FLAGS=-keep-testdata
 #
+# Run test_setup_$os first
 test: clean bucky buckyd
 	go run -mod vendor testing/rebalance.go $(REBALANCE_FLAGS)
 	go run -mod vendor testing/copy.go $(COPY_FLAGS)
 
 # only works on linux
-test_rebalance_health_check_setup:
+test_setup_linux:
 	sudo ip addr add 10.0.1.7 dev lo
 	sudo ip addr add 10.0.1.8 dev lo
 	sudo ip addr add 10.0.1.9 dev lo
+
+test_setup_clean_linux:
+	sudo ip addr del 10.0.1.7/32 dev lo
+	sudo ip addr del 10.0.1.8/32 dev lo
+	sudo ip addr del 10.0.1.9/32 dev lo
+
+test_setup_osx:
+	sudo ifconfig lo0 alias 10.0.1.7 up
+	sudo ifconfig lo0 alias 10.0.1.8 up
+	sudo ifconfig lo0 alias 10.0.1.9 up
+
+test_setup_clean_osx:
+	sudo ifconfig lo0 -alias 10.0.1.7
+	sudo ifconfig lo0 -alias 10.0.1.8
+	sudo ifconfig lo0 -alias 10.0.1.9
 
 test_rebalance_health_check: clean bucky buckyd
 	go run -mod vendor testing/rebalance_health_check.go $(REBALANCE_FLAGS)
@@ -50,6 +66,7 @@ clean_test:
 	rm -rf bucky buckyd
 	rm -rf testdata_rebalance_*
 	rm -rf testdata_copy_*
+	rm -rf testdata_rebalance_health_check_*
 
 clean:
 	$(RM) $(targets)

--- a/cmd/bucky/inconsistent.go
+++ b/cmd/bucky/inconsistent.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -51,22 +50,19 @@ func InconsistentMetrics(hostports []string) (map[string][]string, error) {
 	log.Printf("Hashing...")
 	t := time.Now().Unix()
 	for server, metrics := range list {
-		host, port, err := net.SplitHostPort(server)
+		host, _, err := net.SplitHostPort(server)
 		if err != nil {
 			log.Printf("Malformed hostname: %s", server)
 			return nil, err
 		}
-		if port == "" {
-			port = Cluster.Port
-			server = host + ":" + port
-		}
+
 		for _, m := range metrics {
 			if strings.HasPrefix(m, "carbon.agents.") {
 				// These metrics are inserted into the stream after hashing
 				// is done.  They will never be consistent and shouldn't be.
 				continue
 			}
-			if n := Cluster.Hash.GetNode(m); n.Server != host || strconv.Itoa(n.Port) != port {
+			if Cluster.Hash.GetNode(m).Server != host {
 				results[server] = append(results[server], m)
 			}
 		}

--- a/cmd/bucky/rebalance.go
+++ b/cmd/bucky/rebalance.go
@@ -96,7 +96,7 @@ func RebalanceMetrics(extraHostPorts []string) error {
 		for _, m := range metrics {
 			job := new(syncJob)
 			node := Cluster.Hash.GetNode(m)
-			dst := fmt.Sprintf("%s:%d", node.Server, node.Port)
+			dst := fmt.Sprintf("%s:%s", node.Server, Cluster.Port)
 
 			job.oldName = m
 			job.newName = m
@@ -125,7 +125,6 @@ func RebalanceMetrics(extraHostPorts []string) error {
 			if allowm[dst] {
 				newJobs[dst] = srcm
 			}
-
 		}
 
 		jobs = newJobs

--- a/testing/copy.go
+++ b/testing/copy.go
@@ -64,9 +64,9 @@ func main() {
 	}
 
 	var (
-		server0 = hashing.Node{Server: "localhost", Port: 40000, Instance: "server0"}
-		server1 = hashing.Node{Server: "localhost", Port: 40001, Instance: "server1"}
-		server2 = hashing.Node{Server: "localhost", Port: 40002, Instance: "server2"}
+		server0 = hashing.Node{Server: "10.0.1.7", Port: 4242, Instance: "server0"}
+		server1 = hashing.Node{Server: "10.0.1.8", Port: 4242, Instance: "server1"}
+		server2 = hashing.Node{Server: "10.0.1.9", Port: 4242, Instance: "server2"}
 	)
 
 	if err := os.MkdirAll(filepath.Join(testDir, "server0"), 0755); err != nil {

--- a/testing/rebalance.go
+++ b/testing/rebalance.go
@@ -64,9 +64,9 @@ func main() {
 	}
 
 	var (
-		server0 = hashing.Node{Server: "localhost", Port: 40000, Instance: "server0"}
-		server1 = hashing.Node{Server: "localhost", Port: 40001, Instance: "server1"}
-		server2 = hashing.Node{Server: "localhost", Port: 40002, Instance: "server2"}
+		server0 = hashing.Node{Server: "10.0.1.7", Port: 4242, Instance: "server0"}
+		server1 = hashing.Node{Server: "10.0.1.8", Port: 4242, Instance: "server1"}
+		server2 = hashing.Node{Server: "10.0.1.9", Port: 4242, Instance: "server2"}
 	)
 
 	if err := os.MkdirAll(filepath.Join(testDir, "server0"), 0755); err != nil {

--- a/testing/rebalance_health_check.go
+++ b/testing/rebalance_health_check.go
@@ -70,9 +70,9 @@ func main() {
 	// sudo ip addr add 10.0.1.8 dev lo
 	// sudo ip addr add 10.0.1.9 dev lo
 	var (
-		server0 = hashing.Node{Server: "10.0.1.7", Port: 40000, Instance: "server0"}
-		server1 = hashing.Node{Server: "10.0.1.8", Port: 40001, Instance: "server1"}
-		server2 = hashing.Node{Server: "10.0.1.9", Port: 40002, Instance: "server2"}
+		server0 = hashing.Node{Server: "10.0.1.7", Port: 4242, Instance: "server0"}
+		server1 = hashing.Node{Server: "10.0.1.8", Port: 4242, Instance: "server1"}
+		server2 = hashing.Node{Server: "10.0.1.9", Port: 4242, Instance: "server2"}
 	)
 
 	if err := os.MkdirAll(filepath.Join(testDir, "server0"), 0755); err != nil {


### PR DESCRIPTION
It turns out that carbon_ch and fnv1a_ch algorithms requires full configuration from
relays (like carbon-c-relay) instead of buckytool peer configs. This means that
buckytools can not rely on hash ring configuration for buckytool port inference.

This changes revert the port change introduced in commit a1c42ae16ae6f5f4078840886e6aa158fb2b344a.

Relates to: https://github.com/go-graphite/buckytools/issues/31