### PR TITLE
Propagate syncer errors to exit code

### DIFF
--- a/cmd/bucky/backfill2.go
+++ b/cmd/bucky/backfill2.go
@@ -89,7 +89,9 @@ func (bf2 *backfill2Command) do(c Command) int {
 		}
 	}
 
-	bf2.run(jobs)
-
+	err = bf2.run(jobs)
+	if err != nil {
+		return 1
+	}
 	return 0
 }

--- a/cmd/bucky/copy.go
+++ b/cmd/bucky/copy.go
@@ -51,7 +51,9 @@ func (cc *copyCommand) do(c Command) int {
 		jobs[cc.dst][cc.src] = append(jobs[cc.dst][cc.src], &syncJob{oldName: m, newName: m})
 	}
 
-	cc.run(jobs)
-
+	err = cc.run(jobs)
+	if err != nil {
+		return 1
+	}
 	return 0
 }

--- a/cmd/bucky/rebalance.go
+++ b/cmd/bucky/rebalance.go
@@ -137,9 +137,9 @@ func RebalanceMetrics(extraHostPorts []string) error {
 
 	ms := newMetricSyncer(msFlags)
 
-	ms.run(jobs)
+	err = ms.run(jobs)
 
-	return nil
+	return err
 }
 
 // rebalanceCommand runs this subcommand.


### PR DESCRIPTION
1. Introducing new cli flag - `errortolerance`, default is 0. If after sync we have more then `errortolerance` errors then we return error from sync.run()
2. Propagating error above to `bucky` by proper return it from `rebalance`, `backfill2` and `copy` commands