### PR TITLE
instance can contain any character

### DIFF
--- a/hashing/hashing.go
+++ b/hashing/hashing.go
@@ -137,9 +137,6 @@ func NewNodeParser(s string) (Node, error) {
 			}
 		case 2:
 			// server:port:instance
-			if v == ':' || v == '=' {
-				return Node{}, fmt.Errorf("Error parsing instance in %s", s)
-			}
 			instance = append(instance, v)
 		default:
 			panic("FSM parsing failure")


### PR DESCRIPTION
I don't think that makes sense to unauthorized special characters in instance name.


in carbon-c-relay, we can replace instance by another without changing the hashring and rebalance all data :

 
https://github.com/grobian/carbon-c-relay/blob/master/carbon-c-relay.md?plain=1#L407