### PR TITLE
close whisper files and unlink backup after resizing

### DIFF
--- a/cmd/bucky/modify.go
+++ b/cmd/bucky/modify.go
@@ -132,7 +132,17 @@ func modifyCommand(c Command) int {
 		modifyAgg(target, result, aggMethod)
 	}
 
-	result.Close()
+	if err := result.File().Close(); err != nil {
+		log.Fatalf("could not close file %q: %v", resizeFilename, err)
+	}
+
+	if err := target.File().Close(); err != nil {
+		log.Fatalf("could not close backup file %q: %v", backupFilename, err)
+	}
+
+	if err := os.Remove(backupFilename); err != nil {
+		log.Fatalf("could not unlink backup file %q: %v", backupFilename, err)
+	}
 
 	return 0
 }


### PR DESCRIPTION
This one might be a little more debatable; perhaps there should be a flag controlling this behavior?

As it is, the `.bak` file is left in-place, so efforts to resize whisper files in order to reduce disk space will have the proximate effect of increasing disk space, and the user would have to manually clean up `.bak` files.