### PR TITLE
Adding regex support for backfill2, rebalance and inconsistent commands

### DIFF
--- a/cmd/bucky/backfill2.go
+++ b/cmd/bucky/backfill2.go
@@ -10,6 +10,7 @@ import (
 type backfill2Command struct {
 	srcClusterSeed, dstClusterSeed string
 	metricMapFile                  string
+	allowedMetricRegex             string
 	*metricSyncer
 }
 
@@ -18,6 +19,8 @@ func init() {
 	short := "Copy/Backfill metrics from one cluster to another (can be the same cluster, for massive metric rename and backfill)."
 	long := `Usage:
     bucky backfill2 -offload -src-cluster-seed 10.0.1.7:4242 -dst-cluster-seed 10.0.1.9:4242 -w 3 -ignore404 -metric-map-file metric_map_file.json
+	or
+    bucky backfill2 -offload -src-cluster-seed 10.0.1.7:4242 -dst-cluster-seed 10.0.1.9:4242 -w 3 -ignore404 -r '^mymetricprefix\.|^prefix2\.'
 `
 
 	var bf2Cmd backfill2Command
@@ -30,6 +33,7 @@ func init() {
 	c.Flag.StringVar(&bf2Cmd.srcClusterSeed, "src-cluster-seed", "", "Source cluster seed to copy metrics from.")
 	c.Flag.StringVar(&bf2Cmd.dstClusterSeed, "dst-cluster-seed", "", "Destination cluster seed to copy metrics to.")
 	c.Flag.StringVar(&bf2Cmd.metricMapFile, "metric-map-file", "", "File path to the new metric mapping.")
+	c.Flag.StringVar(&bf2Cmd.allowedMetricRegex, "r", "", "Ignore metric-map-file and only copy/rebalance metrics matching regex. By default (i.e. empty), all metrics are allowed.")
 
 	msFlags.registerFlags(c.Flag)
 
@@ -59,28 +63,69 @@ func (bf2 *backfill2Command) do(c Command) int {
 		return 1
 	}
 
-	metricsMap := map[string]string{}
-	metricsFile, err := os.Open(bf2.metricMapFile)
-	if err != nil {
-		log.Printf("failed to open metric map file: %s", err.Error())
-		return 1
-	}
-	if err := json.NewDecoder(metricsFile).Decode(&metricsMap); err != nil {
-		log.Printf("failed to unmarshal metric map file: %s", err.Error())
-		return 1
-	}
-
-	log.Printf("Number of metrics to copy: %d", len(metricsMap))
-
 	jobs := map[string]map[string][]*syncJob{}
-	for srcm, dstm := range metricsMap {
-		srcServer := fmt.Sprintf("%s:%s", srcCluster.Hash.GetNode(srcm).Server, Cluster.Port)
-		dstServer := fmt.Sprintf("%s:%s", dstCluster.Hash.GetNode(dstm).Server, Cluster.Port)
 
-		if jobs[dstServer] == nil {
-			jobs[dstServer] = map[string][]*syncJob{}
+	if bf2.allowedMetricRegex != "" {
+		hostPorts := srcCluster.HostPorts()
+		if len(hostPorts) == 0 || !srcCluster.Healthy {
+			log.Printf("Cluster is unhealthy or error finding cluster members.")
+			return 1
 		}
-		jobs[dstServer][srcServer] = append(jobs[dstServer][srcServer], &syncJob{OldName: srcm, NewName: dstm})
+		metricMap, err := ListRegexMetrics(hostPorts, bf2.allowedMetricRegex, listForce)
+		if err != nil {
+			log.Printf("Can't get list of metrics to copy.")
+			return 1
+		}
+		log.Printf("Number of metrics to copy: %d", len(metricMap))
+		// make jobs struct in the similar way as rebalance does
+		// but we have our src and dst cluster explicitly
+		moves := make(map[string]int)
+		servers := make([]string, 0)
+		for src, metrics := range metricMap {
+			servers = append(servers, src)
+			for _, m := range metrics {
+				job := new(syncJob)
+				node := dstCluster.Hash.GetNode(m)
+				dst := fmt.Sprintf("%s:%s", node.Server, dstCluster.Port)
+
+				job.OldName = m
+				job.NewName = m
+
+				moves[src]++
+
+				if _, ok := jobs[dst]; !ok {
+					jobs[dst] = map[string][]*syncJob{}
+				}
+				jobs[dst][src] = append(jobs[dst][src], job)
+
+				if msFlags.noop {
+					log.Printf("[%s] %s => %s", src, m, dst)
+				}
+			}
+		}
+	} else {
+		metricsMap := map[string]string{}
+		metricsFile, err := os.Open(bf2.metricMapFile)
+		if err != nil {
+			log.Printf("failed to open metric map file: %s", err.Error())
+			return 1
+		}
+		if err := json.NewDecoder(metricsFile).Decode(&metricsMap); err != nil {
+			log.Printf("failed to unmarshal metric map file: %s", err.Error())
+			return 1
+		}
+
+		log.Printf("Number of metrics to copy: %d", len(metricsMap))
+
+		for srcm, dstm := range metricsMap {
+			srcServer := fmt.Sprintf("%s:%s", srcCluster.Hash.GetNode(srcm).Server, Cluster.Port)
+			dstServer := fmt.Sprintf("%s:%s", dstCluster.Hash.GetNode(dstm).Server, Cluster.Port)
+
+			if jobs[dstServer] == nil {
+				jobs[dstServer] = map[string][]*syncJob{}
+			}
+			jobs[dstServer][srcServer] = append(jobs[dstServer][srcServer], &syncJob{OldName: srcm, NewName: dstm})
+		}
 	}
 
 	log.Println("Copying Stats:")

--- a/cmd/bucky/rebalance.go
+++ b/cmd/bucky/rebalance.go
@@ -8,7 +8,8 @@ import (
 )
 
 var rebalanceConfig struct {
-	allowedDsts string
+	allowedDsts        string
+	allowedMetricRegex string
 }
 
 func init() {
@@ -34,6 +35,10 @@ hosts will be affected even with -s.
 Use --delete to delete metric source locations.  The default is to not remove
 the source metrics.
 
+Use -allowed-dsts to copy/rebalance metrics only to the allowed destinations (ip1:port;ip2:port). By default (i.e. empty), all dsts are allowed.
+
+Use -r to copy/rebalance metrics matching regex. By default (i.e. empty), all metrics are allowed.")
+
 The --no-op option will not alter any metrics and print a report of what
 would have been done.
 
@@ -50,6 +55,7 @@ Set -offload=true to speed up rebalance.`
 	msFlags.registerFlags(c.Flag)
 	c.Flag.BoolVar(&listForce, "f", false, "Force the remote daemons to rebuild their cache.")
 	c.Flag.StringVar(&rebalanceConfig.allowedDsts, "allowed-dsts", "", "Only copy/rebalance metrics to the allowed destinations (ip1:port,ip2:port). By default (i.e. empty), all dsts are allowed.")
+	c.Flag.StringVar(&rebalanceConfig.allowedMetricRegex, "r", "", "Only copy/rebalance metrics matching regex. By default (i.e. empty), all metrics are allowed.")
 }
 
 // countMap returns the number of metrics in a server -> metrics mapping
@@ -78,7 +84,7 @@ func RebalanceMetrics(extraHostPorts []string) error {
 		return fmt.Errorf("cluster is unhealthy")
 	}
 
-	metricMap, err := InconsistentMetrics(hostPorts)
+	metricMap, err := InconsistentMetrics(hostPorts, rebalanceConfig.allowedMetricRegex)
 	if err != nil {
 		return err // error already reported
 	}


### PR DESCRIPTION
* `bucky inconsistent` supports regex filtering for metric lists using the `-r` flag in a similar way to other commands (i.e. du, list, tar, etc), `-r` is a binary flag and the command argument is treated as regex instead of a simple value.
* `bucky rebalance` also supports the `-r' flag, but a bit differently (it is not a binary flag, but a string - you should pass regex as parameter).
* `bucky backfill2` now also supports the `-r` flag, it's also a string flag with parameter (similar to rebalance), but in this case it also completely overrides metric_map.json.