### PR TITLE
caches metric can be missalloccated too

### DIFF
--- a/cmd/bucky/inconsistent.go
+++ b/cmd/bucky/inconsistent.go
@@ -7,10 +7,14 @@ import (
 	"net"
 	"os"
 	"sort"
+	"strings"
 	"time"
 )
 
 // import "github.com/go-graphite/buckytools/hashing"
+
+var inconsistentCacheMetrics bool
+var inconsistentCacheMetricsPrefix string
 
 func init() {
 	usage := "[options]"
@@ -35,9 +39,9 @@ Use bucky rebalance to correct.`
 		"Force the remote daemons to rebuild their cache.")
 	c.Flag.BoolVar(&listRegexMode, "r", false,
 		"Filter by a regular expression.")
-	c.Flag.BoolVar(&listCacheMetrics, "list-cache-metrics", true,
+	c.Flag.BoolVar(&inconsistentCacheMetrics, "list-cache-metrics", true,
 		"Filter carbon cache metrics.")
-	c.Flag.StringVar(&listCacheMetricsPrefix, "cache-metric-prefix", "carbon.agents.",
+	c.Flag.StringVar(&inconsistentCacheMetricsPrefix, "cache-metric-prefix", "carbon.agents.",
 		"cache metric prefix")
 }
 
@@ -66,7 +70,7 @@ func InconsistentMetrics(hostports []string, regex string) (map[string][]string,
 		}
 
 		for _, m := range metrics {
-			if !listCacheMetrics && strings.HasPrefix(m, listCacheMetricsPrefix) {
+			if !inconsistentCacheMetrics && strings.HasPrefix(m, inconsistentCacheMetricsPrefix) {
 				continue
 			}
 			if Cluster.Hash.GetNode(m).Server != host {

--- a/cmd/bucky/inconsistent.go
+++ b/cmd/bucky/inconsistent.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"sort"
-	"strings"
 	"time"
 )
 
@@ -63,11 +62,6 @@ func InconsistentMetrics(hostports []string, regex string) (map[string][]string,
 		}
 
 		for _, m := range metrics {
-			if strings.HasPrefix(m, "carbon.agents.") {
-				// These metrics are inserted into the stream after hashing
-				// is done.  They will never be consistent and shouldn't be.
-				continue
-			}
 			if Cluster.Hash.GetNode(m).Server != host {
 				results[server] = append(results[server], m)
 			}

--- a/cmd/bucky/inconsistent.go
+++ b/cmd/bucky/inconsistent.go
@@ -13,7 +13,7 @@ import (
 
 // import "github.com/go-graphite/buckytools/hashing"
 
-var inconsistentInconsistentCacheMetrics bool
+var inconsistentFilterCacheMetrics bool
 var inconsistentGoCarbonMetricsPrefix string
 
 func init() {
@@ -39,7 +39,7 @@ Use bucky rebalance to correct.`
 		"Force the remote daemons to rebuild their cache.")
 	c.Flag.BoolVar(&listRegexMode, "r", false,
 		"Filter by a regular expression.")
-	c.Flag.BoolVar(&inconsistentInconsistentCacheMetrics, "inconsistent-cache-metrics", false, "Search for go-carbon inconsistent metrics.")
+	c.Flag.BoolVar(&inconsistentFilterCacheMetrics, "filter-cache-metrics", true, "Filter go-carbon inconsistent metrics.")
 	c.Flag.StringVar(&inconsistentGoCarbonMetricsPrefix, "go-carbon-prefix", "carbon.agents.", "go-carbon metric prefix")
 }
 
@@ -68,7 +68,9 @@ func InconsistentMetrics(hostports []string, regex string) (map[string][]string,
 		}
 
 		for _, m := range metrics {
-			if !inconsistentInconsistentCacheMetrics && strings.HasPrefix(m, inconsistentGoCarbonMetricsPrefix) {
+			if inconsistentFilterCacheMetrics && strings.HasPrefix(m, inconsistentGoCarbonMetricsPrefix) {
+				// Graphite cache metrics (usually "carbon.agents.*" metrics) can be inserted into the stream
+				// after hashing has been completed (if written locally). In this case, they will never be consistent and shouldn't be.
 				continue
 			}
 			if Cluster.Hash.GetNode(m).Server != host {

--- a/cmd/bucky/inconsistent.go
+++ b/cmd/bucky/inconsistent.go
@@ -35,6 +35,10 @@ Use bucky rebalance to correct.`
 		"Force the remote daemons to rebuild their cache.")
 	c.Flag.BoolVar(&listRegexMode, "r", false,
 		"Filter by a regular expression.")
+	c.Flag.BoolVar(&listCacheMetrics, "list-cache-metrics", true,
+		"Filter carbon cache metrics.")
+	c.Flag.StringVar(&listCacheMetricsPrefix, "cache-metric-prefix", "carbon.agents.",
+		"cache metric prefix")
 }
 
 func InconsistentMetrics(hostports []string, regex string) (map[string][]string, error) {
@@ -62,6 +66,9 @@ func InconsistentMetrics(hostports []string, regex string) (map[string][]string,
 		}
 
 		for _, m := range metrics {
+			if !listCacheMetrics && strings.HasPrefix(m, listCacheMetricsPrefix) {
+				continue
+			}
 			if Cluster.Hash.GetNode(m).Server != host {
 				results[server] = append(results[server], m)
 			}

--- a/cmd/bucky/inconsistent.go
+++ b/cmd/bucky/inconsistent.go
@@ -13,8 +13,8 @@ import (
 
 // import "github.com/go-graphite/buckytools/hashing"
 
-var inconsistentCacheMetrics bool
-var inconsistentCacheMetricsPrefix string
+var inconsistentInconsistentCacheMetrics bool
+var inconsistentGoCarbonMetricsPrefix string
 
 func init() {
 	usage := "[options]"
@@ -39,10 +39,8 @@ Use bucky rebalance to correct.`
 		"Force the remote daemons to rebuild their cache.")
 	c.Flag.BoolVar(&listRegexMode, "r", false,
 		"Filter by a regular expression.")
-	c.Flag.BoolVar(&inconsistentCacheMetrics, "list-cache-metrics", true,
-		"Filter carbon cache metrics.")
-	c.Flag.StringVar(&inconsistentCacheMetricsPrefix, "cache-metric-prefix", "carbon.agents.",
-		"cache metric prefix")
+	c.Flag.BoolVar(&inconsistentInconsistentCacheMetrics, "inconsistent-cache-metrics", false, "Search for go-carbon inconsistent metrics.")
+	c.Flag.StringVar(&inconsistentGoCarbonMetricsPrefix, "go-carbon-prefix", "carbon.agents.", "go-carbon metric prefix")
 }
 
 func InconsistentMetrics(hostports []string, regex string) (map[string][]string, error) {
@@ -70,7 +68,7 @@ func InconsistentMetrics(hostports []string, regex string) (map[string][]string,
 		}
 
 		for _, m := range metrics {
-			if !inconsistentCacheMetrics && strings.HasPrefix(m, inconsistentCacheMetricsPrefix) {
+			if !inconsistentInconsistentCacheMetrics && strings.HasPrefix(m, inconsistentGoCarbonMetricsPrefix) {
 				continue
 			}
 			if Cluster.Hash.GetNode(m).Server != host {

--- a/cmd/bucky/rebalance.go
+++ b/cmd/bucky/rebalance.go
@@ -56,7 +56,7 @@ Set -offload=true to speed up rebalance.`
 	c.Flag.BoolVar(&listForce, "f", false, "Force the remote daemons to rebuild their cache.")
 	c.Flag.StringVar(&rebalanceConfig.allowedDsts, "allowed-dsts", "", "Only copy/rebalance metrics to the allowed destinations (ip1:port,ip2:port). By default (i.e. empty), all dsts are allowed.")
 	c.Flag.StringVar(&rebalanceConfig.allowedMetricRegex, "r", "", "Only copy/rebalance metrics matching regex. By default (i.e. empty), all metrics are allowed.")
-	c.Flag.BoolVar(&inconsistentInconsistentCacheMetrics, "inconsistent-cache-metrics", false, "Search for go-carbon inconsistent metrics.")
+	c.Flag.BoolVar(&inconsistentFilterCacheMetrics, "filter-cache-metrics", true, "Filter go-carbon inconsistent metrics.")
 	c.Flag.StringVar(&inconsistentGoCarbonMetricsPrefix, "go-carbon-prefix", "carbon.agents.", "go-carbon metric prefix")
 }
 

--- a/cmd/bucky/rebalance.go
+++ b/cmd/bucky/rebalance.go
@@ -56,6 +56,8 @@ Set -offload=true to speed up rebalance.`
 	c.Flag.BoolVar(&listForce, "f", false, "Force the remote daemons to rebuild their cache.")
 	c.Flag.StringVar(&rebalanceConfig.allowedDsts, "allowed-dsts", "", "Only copy/rebalance metrics to the allowed destinations (ip1:port,ip2:port). By default (i.e. empty), all dsts are allowed.")
 	c.Flag.StringVar(&rebalanceConfig.allowedMetricRegex, "r", "", "Only copy/rebalance metrics matching regex. By default (i.e. empty), all metrics are allowed.")
+	c.Flag.BoolVar(&inconsistentInconsistentCacheMetrics, "inconsistent-cache-metrics", false, "Search for go-carbon inconsistent metrics.")
+	c.Flag.StringVar(&inconsistentGoCarbonMetricsPrefix, "go-carbon-prefix", "carbon.agents.", "go-carbon metric prefix")
 }
 
 // countMap returns the number of metrics in a server -> metrics mapping


### PR DESCRIPTION
Hello !

I think this piece of code that doesn't give the "carbon.agents.*" metrics as inconsistent doesn't make much sense:

1. "carbon.agents" is just the default but can be updated to whatever we want.
2. In the case of a caches cluster, you only need to send the internal metric to the upstream relay to have the metric in the right position for hashring.


an other solution is to allow to set the prefix to a custom value and/or allow to disable this filter